### PR TITLE
updated petCard css to prevent pet name from flowing out of box

### DIFF
--- a/frontend/src/styles/PetCard.css
+++ b/frontend/src/styles/PetCard.css
@@ -50,15 +50,16 @@
     border-color: #6b5b95;
     border-radius: 1rem;
     align-items: center;
+    justify-content: space-between;
 }
 
 .name {
-    margin: auto;
     justify-self: center;
     text-overflow: ellipsis;
     text-wrap: nowrap;
     overflow: hidden;
-    margin: 5%;
+    margin-top: 5%;
+    margin-bottom: 5%;
 }
 
 .fav {
@@ -70,6 +71,7 @@
     margin-right: .5rem;
     background: transparent;
     border: none;
+    padding-top: .25rem; 
 }
 
 .fav:hover {

--- a/frontend/src/styles/PetCard.css
+++ b/frontend/src/styles/PetCard.css
@@ -55,6 +55,10 @@
 .name {
     margin: auto;
     justify-self: center;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+    overflow: hidden;
+    margin: 5%;
 }
 
 .fav {

--- a/frontend/src/styles/PetCard.css
+++ b/frontend/src/styles/PetCard.css
@@ -17,7 +17,7 @@
 
 .image {
     background-color: #5AD8CC;
-    margin: 1rem auto 2rem auto;
+    margin: 1rem auto 1rem auto;
     border-radius: .5rem;
     width: 80%;
     aspect-ratio: 1/1;
@@ -107,4 +107,11 @@
     font-size: .75rem;
     margin-top: 0px;
     margin-bottom: 2rem;
+    justify-self: center;
+    text-overflow: ellipsis;
+    text-wrap: nowrap;
+    overflow: hidden;
+    padding: 0 2rem;
+    width: 75%;
+    text-align: center;
 }


### PR DESCRIPTION
## Description

Brief summary of changes made in this pull request.
- added several constraints to get the pet name on the pet card to stay within the styled pet name box but not be off-center, wrap onto a new line, or run over the favorite heart. Ended up just using ellipsis because that's how I got it to work and figured if it's working it is good!
- all changes were made within the stylesheet PetCard.css and specifically within the class section: .name

## Check list

- [ ] Have you rebased the branch on top of the latest change in main?
- [ ] Is your code getting reviewed?
- [ ] Have you squashed your code after getting approved?
